### PR TITLE
feat: add theme color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 - Nuxt 3 and Nuxt Bridge support
 - Add `.${color}-mode` class to `<html>` for easy CSS theming
+- Automatically set [theme color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) of the page
 - Force a page to a specific color mode (perfect for incremental development)
 - Works with client-side and universal rendering
 - Auto detect system [color-mode](https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-mode)

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -16,6 +16,7 @@ v3 of `@nuxtjs/color-mode` is compatible with [Nuxt 3 and Nuxt Bridge](https://v
 
 - Nuxt 3 and Nuxt Bridge support
 - Add `.${color}-mode` class to `<html>` for easy CSS theming
+- Automatically set [theme color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) of the page
 - Force a page to a specific color mode (perfect for incremental development)
 - Works with client-side and universal rendering
 - Auto detect system [color-mode](https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-mode)
@@ -158,7 +159,8 @@ export default defineNuxtConfig({
     componentName: 'ColorScheme',
     classPrefix: '',
     classSuffix: '-mode',
-    storageKey: 'nuxt-color-mode'
+    storageKey: 'nuxt-color-mode',
+    themeColors: null
   }
 })
 ```

--- a/playground/nuxt.config.js
+++ b/playground/nuxt.config.js
@@ -4,5 +4,12 @@ import colorModeModule from '..'
 export default defineNuxtConfig({
   components: { global: true, dirs: ['~/components'] },
   css: ['~/assets/main.css'],
-  modules: [colorModeModule]
+  modules: [colorModeModule],
+  colorMode: {
+    themeColors: {
+      dark: '#091a28',
+      light: '#f3f5f4',
+      sepia: '#f1e7d0'
+    }
+  }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,8 @@ const DEFAULTS: ModuleOptions = {
   classPrefix: '',
   classSuffix: '-mode',
   dataValue: '',
-  storageKey: 'nuxt-color-mode'
+  storageKey: 'nuxt-color-mode',
+  themeColors: null
 }
 
 export default defineNuxtModule({
@@ -33,7 +34,12 @@ export default defineNuxtModule({
     // Read script from disk and add to options
     const scriptPath = await resolver.resolve('./script.min.js')
     const scriptT = await fsp.readFile(scriptPath, 'utf-8')
-    options.script = template(scriptT)({ options })
+    options.script = template(scriptT)({
+      options: {
+        ...options,
+        themeColors: JSON.stringify(options.themeColors)
+      }
+    })
 
     // Inject options via virtual template
     nuxt.options.alias['#color-mode-options'] = addTemplate({

--- a/src/module.ts
+++ b/src/module.ts
@@ -158,4 +158,8 @@ export interface ModuleOptions {
    * The script that will be injected into the head of the page
    */
   script?: string
+  /**
+   * Default: null
+   */
+  themeColors: Record<string, string> | null
 }

--- a/src/script.ts
+++ b/src/script.ts
@@ -2,14 +2,15 @@
 
 // Global variable minimizers
 const w = window
-const de = document.documentElement
+const d = document
+const de = d.documentElement
 
 const knownColorSchemes = ['dark', 'light']
 
 const preference = window.localStorage.getItem('<%= options.storageKey %>') || '<%= options.preference %>'
-const themeColors = JSON.parse('<%= options.escapedThemeColors %>')
+const themeColors = JSON.parse('<%= options.themeColors %>')
 // Get previous meta element if the script is run the second time (e.g. in dev mode)
-let themeColorMetaElm = d.head.querySelector('meta[data-nuxtjs-color-mode]')
+let themeColorMetaElm = d.head.querySelector('meta[name=theme-color]')
 let value = preference === 'system' ? getColorScheme() : preference
 // Applied forced color mode
 const forcedColorMode = de.getAttribute('data-color-mode-forced')
@@ -43,7 +44,6 @@ function addColorScheme (value) {
   if (themeColor) {
     if (!themeColorMetaElm) {
       themeColorMetaElm = d.createElement('meta')
-      themeColorMetaElm.setAttribute('data-nuxtjs-color-mode', '')
       themeColorMetaElm.name = 'theme-color'
     }
     themeColorMetaElm.content = themeColor

--- a/src/script.ts
+++ b/src/script.ts
@@ -7,6 +7,9 @@ const de = document.documentElement
 const knownColorSchemes = ['dark', 'light']
 
 const preference = window.localStorage.getItem('<%= options.storageKey %>') || '<%= options.preference %>'
+const themeColors = JSON.parse('<%= options.escapedThemeColors %>')
+// Get previous meta element if the script is run the second time (e.g. in dev mode)
+let themeColorMetaElm = d.head.querySelector('meta[data-nuxtjs-color-mode]')
 let value = preference === 'system' ? getColorScheme() : preference
 // Applied forced color mode
 const forcedColorMode = de.getAttribute('data-color-mode-forced')
@@ -34,6 +37,21 @@ function addColorScheme (value) {
   }
   if (dataValue) {
     de.setAttribute('data-' + dataValue, value)
+  }
+
+  const themeColor = themeColors && themeColors[value]
+  if (themeColor) {
+    if (!themeColorMetaElm) {
+      themeColorMetaElm = d.createElement('meta')
+      themeColorMetaElm.setAttribute('data-nuxtjs-color-mode', '')
+      themeColorMetaElm.name = 'theme-color'
+    }
+    themeColorMetaElm.content = themeColor
+    if (themeColorMetaElm.parentNode !== d.head) {
+      d.head.appendChild(themeColorMetaElm)
+    }
+  } else if (themeColorMetaElm && themeColorMetaElm.parentNode) {
+    themeColorMetaElm.parentNode.removeChild(themeColorMetaElm)
   }
 }
 


### PR DESCRIPTION
Allow specifying [theme-color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) according to the current dark/light mode configuration.

Implementing this outside of `color-mode-module` has the following caveats:

1. The user may have set custom color mode via localStorage. Since the server or renderer cannot know this, it cannot emit appropriate `<meta name="theme-color" content="...">` tags in the raw HTML. If we always used the system color mode, we could use the `media="..."` attribute, but this does not apply to our case.
2. Implementing in nuxt init hook leads to title bar flicker, since we have to wait until Nuxt finishes initializing before we could add the `theme-color` meta tag.
3. Injecting a custom script tag may not work reliably if the developer cannot control the order of script inclusion. Also, if the developer uses custom `storageKey`, the developer also have to make sure the custom script always uses the same storage key.

Making the theme-color support built-in solves all of the problems above.

Note: dynamic `theme-color` is out of scope, since there would be no elegant way to specify this. The user can still implement their own `theme-color` setting mechanism despite the caveats.