### PR TITLE
refactor: convert `ColorScheme` to script setup

### DIFF
--- a/src/runtime/component.vue3.vue
+++ b/src/runtime/component.vue3.vue
@@ -1,20 +1,23 @@
 <script lang="ts">
 import { componentName } from '#color-mode-options'
-
 export default {
-  name: componentName,
-  props: {
-    placeholder: String,
-    tag: {
-      type: String,
-      default: 'span'
-    }
-  }
+  name: componentName
 }
 </script>
 
+<script setup lang="ts">
+import { defineProps, withDefaults } from '#imports'
+
+const props = withDefaults(defineProps<{
+  placeholder: string
+  tag?: string
+}>(), {
+  tag: 'div'
+})
+</script>
+
 <template>
-  <ClientOnly :placeholder="placeholder" :placeholder-tag="tag">
+  <ClientOnly :placeholder="props.placeholder" :placeholder-tag="props.tag">
     <slot />
   </ClientOnly>
 </template>


### PR DESCRIPTION
Resolves #168 (Hopefully?)

I changed the previous implementation of the `ColorScheme` component to the following:
```html
<script lang="ts">
import { componentName } from '#color-mode-options'
export default {
  name: componentName
}
</script>

<script setup lang="ts">
import { defineProps, withDefaults } from '#imports'

const props = withDefaults(defineProps<{
  placeholder: string
  tag?: string
}>(), {
  tag: 'div'
})
</script>

<template>
  <ClientOnly :placeholder="props.placeholder" :placeholder-tag="props.tag">
    <slot />
  </ClientOnly>
</template>
```

and indeed, the project that was complaining about types did recognize it correctly. However, when launching dev server, I get:
```
 ERROR  [@vue/compiler-sfc] <script> and <script setup> must have the same language type.
 [Vue warn]: Unhandled error during execution of setup function 
  at <Anonymous key="default" name="default" hasTransition=false >
```

And indeed, when looking into node_modules file, first `script` tag doesn't have `lang="ts"` in it. It might be something on my machine, where it uses old version of something, and I would greatly appreciate if anybody else tried running this

cc @Atinux 