### PR TITLE
docs: add note for `colorMode.dataValue` option

### DIFF
--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -149,6 +149,7 @@ export default defineNuxtConfig({
 
 Notes:
 - `'system'` is a special value; it will automatically detect the color mode based on the system preferences (see [prefers-color-mode spec](https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-mode)). The value injected will be either `'light'` or `'dark'`. If `no-preference` is detected or the browser does not handle color-mode, it will set the `fallback` value.
+- Optional `colorMode.dataValue` lets you add dataset to the `html`, for example if you currently have `class="dark"` on `html`, `dataValue: 'theme'` will also set `data-theme="dark"` on `html`. This is useful when using library like daisyUI that uses `data-theme="light"` on `html` to apply theme.
 
 ## Caveats
 

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -149,7 +149,7 @@ export default defineNuxtConfig({
 
 Notes:
 - `'system'` is a special value; it will automatically detect the color mode based on the system preferences (see [prefers-color-mode spec](https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-mode)). The value injected will be either `'light'` or `'dark'`. If `no-preference` is detected or the browser does not handle color-mode, it will set the `fallback` value.
-- Optional `colorMode.dataValue` lets you add dataset to the `html`, for example if you currently have `class="dark"` on `html`, `dataValue: 'theme'` will also set `data-theme="dark"` on `html`. This is useful when using library like daisyUI that uses `data-theme="light"` on `html` to apply theme.
+- Optional `dataValue` lets you add dataset to the `html`, for example if you currently have `class="dark"` on `html`, `dataValue: 'theme'` will also set `data-theme="dark"` on `html`. This is useful when using library like daisyUI that uses `data-theme="light"` on `html` to apply theme.
 
 ## Caveats
 


### PR DESCRIPTION
I found this option is quite useful but it is currently missing in the document.