### PR TITLE
feat: Add usage of theme header from http request

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -6,6 +6,8 @@ import { globalName, storageKey, dataValue } from '#color-mode-options'
 
 const helper = window[globalName] as unknown as {
   preference: string
+  systemScheme: string | null
+  getSystemScheme: () => string | null
   value: string
   getColorScheme: () => string
   addColorScheme: (className: string) => void
@@ -16,6 +18,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const colorMode = useState<ColorModeInstance>('color-mode', () => reactive({
     // For SPA mode or fallback
     preference: helper.preference,
+    systemScheme: helper.systemScheme,
     value: helper.value,
     unknown: false,
     forced: false
@@ -65,6 +68,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     darkWatcher = window.matchMedia('(prefers-color-scheme: dark)')
     darkWatcher.addEventListener('change', () => {
+      colorMode.systemScheme = helper.getSystemScheme()
+
       if (!colorMode.forced && colorMode.preference === 'system') {
         colorMode.value = helper.getColorScheme()
       }

--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -16,14 +16,14 @@ const addScript = (head) => {
   head[serializeProp][hid] = ['innerHTML']
 }
 
-const themeHeader = 'Sec-CH-Prefers-Color-Scheme';
-const getSystemThemeFromReq = (req: IncomingMessage): string | null => {
+const schemeHeader = 'Sec-CH-Prefers-Color-Scheme';
+const getSystemSchemeFromReq = (req: IncomingMessage): string | null => {
   return req.headers[
-    themeHeader.toLowerCase()
+    schemeHeader.toLowerCase()
   ] as string || null;
 }
-const setThemeHeaderForRes = (res: ServerResponse): void => {
-  res.setHeader('Accept-CH', themeHeader);
+const setSchemeHeaderForRes = (res: ServerResponse): void => {
+  res.setHeader('Accept-CH', schemeHeader);
 }
 
 export default defineNuxtPlugin((nuxtApp) => {
@@ -32,26 +32,27 @@ export default defineNuxtPlugin((nuxtApp) => {
   if (nuxtApp.ssrContext && 'islandContext' in nuxtApp.ssrContext) {
     colorMode = reactive({} as ColorModeInstance);
   } else {
-    let systemTheme: string | null = null;
+    let systemScheme: string | null = null;
 
     if (isVue2) {
       const { req, res } = nuxtApp.nuxt2Context;
 
-      setThemeHeaderForRes(res);
+      setSchemeHeaderForRes(res);
 
-      systemTheme = getSystemThemeFromReq(req) || systemTheme;
+      systemScheme = getSystemSchemeFromReq(req) || systemScheme;
     } else {
       const { req, res } = useRequestEvent()?.node || {};
 
-      setThemeHeaderForRes(res);
+      setSchemeHeaderForRes(res);
 
-      systemTheme = getSystemThemeFromReq(req) || systemTheme;
+      systemScheme = getSystemSchemeFromReq(req) || systemScheme;
     }
 
     colorMode = useState<ColorModeInstance>('color-mode', () => reactive({
       preference,
-      value: systemTheme || preference,
-      unknown: !systemTheme,
+      systemScheme,
+      value: systemScheme || preference,
+      unknown: !systemScheme,
       forced: false
     })).value
   }

--- a/src/runtime/plugin.server.ts
+++ b/src/runtime/plugin.server.ts
@@ -58,10 +58,6 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const htmlAttrs: Record<string, string> = {}
 
-  if ('unknown' in colorMode && !colorMode.unknown) {
-    htmlAttrs[`data-${dataValue}`] = colorMode.value
-  }
-
   if (isVue2) {
     const app = nuxtApp.nuxt2Context.app
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export interface ColorModeInstance {
   preference: string
+  systemScheme: string | null
   value: string
   unknown: boolean
   forced: boolean

--- a/src/script.ts
+++ b/src/script.ts
@@ -7,6 +7,7 @@
   const knownColorSchemes = ['dark', 'light']
 
   const preference = (window && window.localStorage && window.localStorage.getItem && window.localStorage.getItem('<%= options.storageKey %>')) || '<%= options.preference %>'
+  const systemScheme = getSystemScheme()
   let value = preference === 'system' ? getColorScheme() : preference
   // Applied forced color mode
   const forcedColorMode = de.getAttribute('data-color-mode-forced')
@@ -19,7 +20,9 @@
   // @ts-ignore
   w['<%= options.globalName %>'] = {
     preference,
+    systemScheme,
     value,
+    getSystemScheme,
     getColorScheme,
     addColorScheme,
     removeColorScheme
@@ -58,7 +61,7 @@
     return w.matchMedia('(prefers-color-scheme' + suffix + ')')
   }
 
-  function getColorScheme () {
+  function getSystemScheme () {
     // @ts-ignore
     if (w.matchMedia && prefersColorScheme('').media !== 'not all') {
       for (const colorScheme of knownColorSchemes) {
@@ -68,6 +71,10 @@
       }
     }
 
-    return '<%= options.fallback %>'
+    return null;
+  }
+
+  function getColorScheme () {
+    return getSystemScheme() || '<%= options.fallback %>'
   }
 })()


### PR DESCRIPTION
fix #218

Currently i add detecting of user theme from http request, but don't understand how it work with `nuxtApp.ssrContext && 'islandContext' in nuxtApp.ssrContext`