### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -31,18 +31,9 @@ The current version of `@nuxtjs/color-mode` is compatible with [Nuxt 3 and Nuxt 
 ::
 
 Add `@nuxtjs/color-mode` dependency to your project:
-
-::code-group
-```bash [Yarn]
-yarn add --dev @nuxtjs/color-mode
+```bash
+npx nuxi@latest module add color-mode
 ```
-```bash [NPM]
-npm install --save-dev @nuxtjs/color-mode
-```
-```bash [PNPM]
-pnpm i --save-dev @nuxtjs/color-mode
-```
-::
 
 Then, add `@nuxtjs/color-mode` to the `modules` section of your `nuxt.config.ts`
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
