### PR TITLE
fix: synchronize Vue 2 & 3 component behaviour

### DIFF
--- a/src/runtime/component.vue2.vue
+++ b/src/runtime/component.vue2.vue
@@ -13,7 +13,7 @@ export default {
   },
   render(createElement, { data, props, children, slots }) {
     // transform props for <client-only>
-    if (slots.placeholder) {
+    if (!props.placeholder && slots.placeholder) {
       props = {
         placeholderTag: props.placeholderTag,
       }


### PR DESCRIPTION
Overlook in nuxt-modules/color-mode#282

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

Synchronize behaviour between 2 component version.

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
