### PR TITLE
Corrected typo: Install command was missing a space

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -28,7 +28,7 @@ The current version of `@nuxtjs/color-mode` is compatible with [Nuxt 3 and Nuxt 
 Add `@nuxtjs/color-mode` dependency to your project:
 
 ```bash
-npx nuximodule add color-mode
+npx nuxi module add color-mode
 ```
 
 Then, add `@nuxtjs/color-mode` to the `modules` section of your `nuxt.config.ts`


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #286.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added a space to the install command to turn `npx nuximodule add color-mode` into `nuxi module add color-mode`.

Formerly: 
![Screenshot 2024-09-14 165403](https://github.com/user-attachments/assets/87112cd9-b34a-4108-ae29-546a3215266d)

