### PR TITLE
feat!: drop default classSuffix

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -130,7 +130,7 @@ export default defineNuxtConfig({
     globalName: '__NUXT_COLOR_MODE__',
     componentName: 'ColorScheme',
     classPrefix: '',
-    classSuffix: '-mode',
+    classSuffix: '',
     storage: 'localStorage', // or 'sessionStorage' or 'cookie'
     storageKey: 'nuxt-color-mode'
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,7 @@ const DEFAULTS: ModuleOptions = {
   globalName: '__NUXT_COLOR_MODE__',
   componentName: 'ColorScheme',
   classPrefix: '',
-  classSuffix: '-mode',
+  classSuffix: '',
   dataValue: '',
   storageKey: 'nuxt-color-mode',
   storage: 'localStorage',
@@ -160,7 +160,7 @@ export interface ModuleOptions {
    */
   classPrefix: string
   /**
-   * @default '-mode'
+   * @default ''
    */
   classSuffix: string
   /**


### PR DESCRIPTION
### 🔗 Linked issue

resolves #314 

### ❓ Type of change

Updates the default value for `classSuffix` from `'-mode'` to `''`.

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Various Nuxt modules (like [@nuxt/content](https://github.com/nuxt/content/issues/3259)) and websites rely on the `classSuffix` to be `''`, which means that the default settings of `color-mode` aren't compatible. As per @atinux's comment in #314, we can change the default to `''`, which in turn allows package consumers like ([@nuxt/ui](https://github.com/nuxt/ui/blob/57efc78a3b3fa4a54bcd13df47d570a18fba2bc4/src/module.ts#L97)) to drop this setting override.