### PR TITLE
Update plugin.client.ts

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -79,7 +79,8 @@ export default defineNuxtPlugin((nuxtApp) => {
   function setPreferenceToStorage(storageType: typeof storage, preference: string) {
     switch (storageType) {
       case 'cookie':
-        window.document.cookie = storageKey + '=' + preference
+        const oneYear = 60 * 60 * 24 * 365 
+        window.document.cookie = `${storageKey}=${preference}; max-age=${oneYear}; path=/`;
         break
       case 'sessionStorage':
         window.sessionStorage?.setItem(storageKey, preference)


### PR DESCRIPTION
Set the path of the cookie to the root directory , path=/


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [√ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When using @nuxtjs/i18n with strategy: 'prefix_and_default'—so that URLs include a language prefix, including for the default locale—and configuring @nuxtjs/color-mode to use cookie-based storage, the following issues occur upon switching language:

- A new color-mode cookie gets created under the current locale path (e.g., /fr)

- The cookie resets to its default value, trouncing the user’s previously selected color mode

### Expected behavior:

- The user’s theme preference should persist across language changes

- The color-mode cookie should be scoped to the root path (/), not confined to locale-specific subpaths

### Steps to reproduce:

1. Set @nuxtjs/i18n with strategy: 'prefix_and_default'

1. Configure @nuxtjs/color-mode to store preference via cookie

3. Visit the site, switch to dark mode, and inspect the cookie’s scope in dev tools

4. Switch language and observe the creation of a locale-scoped cookie, with the preference reset
